### PR TITLE
Fixes player and level duplications

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,12 +11,11 @@ config_version=4
 [application]
 
 config/name="Sponge Platformer"
-run/main_scene="res://scenes/level/Game.tscn"
+run/main_scene="res://scenes/Empty.tscn"
 config/icon="res://icon.png"
 
 [autoload]
 
-Global_player="*res://scripts/Sponge.gd"
 Global_game="*res://scenes/level/Game.tscn"
 
 [display]

--- a/scenes/Empty.tscn
+++ b/scenes/Empty.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=2]
+
+[node name="Spatial" type="Spatial"]


### PR DESCRIPTION
![sponge_double_games](https://user-images.githubusercontent.com/47012977/177197119-921d4703-d2fa-4a38-ab32-93eaf728e8d0.png)
I had a look at the remote tree (when running the game under debug like with F5, the remote tab appears in the Scene tab. It shows you the nodes as they currently exist in the running game) and found out that there were two instances of the level, and 3 instances of the player. The reason you had two "Games" is that one is an autoload, and the other is your default scene you run when pressing F5.

The global player is an autoload, but it's useless since it's not even positionned properly in the level. The other two players are overlapping in the overlapped levels. The reason you had 4 printouts was because each player was triggering both end level areas, causing 4 signals to be sent out. These four signals caused 4 next levels to be instanced, and then 8, and then 16 etc. until it would crash or just become really laggy.
![sponge_platformer_level_duplicates](https://user-images.githubusercontent.com/47012977/177197654-412da897-fec1-4116-a17a-be42c984ce85.png)
![sponge_platformer_level_duplicates2](https://user-images.githubusercontent.com/47012977/177197658-2fc519ca-98ab-42e7-8aa0-26ed65f68568.png)


I removed the autoload player since the player in the Game autoload was the real one. I also changed the default scene to an empty one. This is just a quick dirty fix, a better fix would be to rework your game scene and maybe not make it an autoload.

